### PR TITLE
Show script and hide script button label correction

### DIFF
--- a/source/resource/cboulanger/eventrecorder/forms/editor.xml
+++ b/source/resource/cboulanger/eventrecorder/forms/editor.xml
@@ -111,7 +111,7 @@
   <script action="toggleLeftEditor"><![CDATA[
         let leftEditorVisible = $.Form.getModel().getLeftEditorVisible();
         $.Form.getModel().setLeftEditorVisible(!leftEditorVisible);
-        $("#toggleLeftEditorButton").setLabel(leftEditorVisible? "Hide script" : "Show script");
+        $("#toggleLeftEditorButton").setLabel(leftEditorVisible? "Show script" : "Hide script");
       ]]>
   </script>
   <script action="toggleRightEditor"><![CDATA[


### PR DESCRIPTION
The show script/hide script button is now consistent with the show translation hide translation button. 

The variable leftEditorVisible actually corresponds to the previous visibility, not the new visibility.